### PR TITLE
Extend dyn type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ The Spice grammar can be found [here](./compiler/src/grammar/Spice.g4) as a ANTL
 - [x] Postfix unary operators are only applied to intentifiers of type integer
 - [x] Program contains main function
 
-## To be tested
+## To be tested / support missing
 - [ ] Dyn data type for function args
 - [ ] Dyn data type as function return types
+- [ ] Functions can be overloaded
+- [ ] Optional parameters can be omitted when calling functions/procedures
 
 ## Special language features
 - Something like `"Test" * 3` is valid and will evaluate to `"TestTestTest"`

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ The Spice grammar can be found [here](./compiler/src/grammar/Spice.g4) as a ANTL
 - [x] Prefix unary operators are only applied to integers
 - [x] Postfix unary operators are only applied to intentifiers of type integer
 - [x] Program contains main function
+- [x] Dyn data type for function args
+- [x] Dyn data type as function return types
 
 ## To be tested / support missing
-- [ ] Dyn data type for function args
-- [ ] Dyn data type as function return types
 - [ ] Functions can be overloaded
 - [ ] Optional parameters can be omitted when calling functions/procedures
 

--- a/compiler/.run/Spice_run.run.xml
+++ b/compiler/.run/Spice_run.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Spice_run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="&quot;../../../media/fibonacci.spice&quot; &quot;&quot; &quot;output.o&quot;" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="Spice_run" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="Spice_run">
+  <configuration default="false" name="Spice_run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="&quot;../../../media/functions.spice&quot; &quot;&quot; &quot;output.o&quot;" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="Spice_run" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="Spice_run">
     <envs>
       <env name="WITH_TESTS" value="OFF" />
     </envs>

--- a/compiler/src/analyzer/AnalyzerVisitor.cpp
+++ b/compiler/src/analyzer/AnalyzerVisitor.cpp
@@ -105,8 +105,7 @@ antlrcpp::Any AnalyzerVisitor::visitForLoop(SpiceParser::ForLoopContext* ctx) {
 
 /*antlrcpp::Any AnalyzerVisitor::visitForeachLoop(SpiceParser::ForeachLoopContext* ctx) {
     // Create a new scope
-    std::string scopeId = "foreach:" + std::to_string(ctx->FOR()->getSymbol()->getLine()) + ":" +
-                          std::to_string(ctx->FOR()->getSymbol()->getCharPositionInLine());
+    std::string scopeId = ScopeIdUtil::getScopeId(ctx);
     currentScope = currentScope->createChildBlock(scopeId);
 }*/
 
@@ -137,6 +136,19 @@ antlrcpp::Any AnalyzerVisitor::visitIfStmt(SpiceParser::IfStmtContext* ctx) {
     visit(ctx->stmtLst());
     // Return to old scope
     currentScope = currentScope->getParent();
+    return TYPE_BOOL;
+}
+
+antlrcpp::Any AnalyzerVisitor::visitParamLstDef(SpiceParser::ParamLstDefContext *ctx) {
+    for (auto& param : ctx->declStmt()) { // Parameters without default value
+        SymbolType paramType = visit(param).as<SymbolType>();
+        std::string paramName = param->IDENTIFIER()->toString();
+        if (paramType == TYPE_DYN)
+            throw SemanticError(FCT_PARAM_IS_TYPE_DYN, "Type of parameter '" + paramName + "' is invalid");
+    }
+    for (auto& param : ctx->assignment()) { // Parameters with default value
+        visit(param);
+    }
     return TYPE_BOOL;
 }
 

--- a/compiler/src/analyzer/AnalyzerVisitor.h
+++ b/compiler/src/analyzer/AnalyzerVisitor.h
@@ -21,6 +21,7 @@ public:
     /*antlrcpp::Any visitForeachLoop(SpiceParser::ForeachLoopContext* ctx) override;*/
     antlrcpp::Any visitWhileLoop(SpiceParser::WhileLoopContext* ctx) override;
     antlrcpp::Any visitIfStmt(SpiceParser::IfStmtContext* ctx) override;
+    antlrcpp::Any visitParamLstDef(SpiceParser::ParamLstDefContext *ctx) override;
     antlrcpp::Any visitDeclStmt(SpiceParser::DeclStmtContext* ctx) override;
     antlrcpp::Any visitFunctionCall(SpiceParser::FunctionCallContext* ctx) override;
     antlrcpp::Any visitImportStmt(SpiceParser::ImportStmtContext* ctx) override;

--- a/compiler/src/analyzer/AnalyzerVisitor.h
+++ b/compiler/src/analyzer/AnalyzerVisitor.h
@@ -8,7 +8,7 @@
 #include <util/ScopeIdUtil.h>
 #include <exception/SemanticError.h>
 
-const std::string RETURN_VARIABLE_NAME = "result";
+const static std::string RETURN_VARIABLE_NAME = "result";
 
 class AnalyzerVisitor : public SpiceBaseVisitor {
 public:

--- a/compiler/src/analyzer/SymbolTable.cpp
+++ b/compiler/src/analyzer/SymbolTable.cpp
@@ -13,7 +13,7 @@ SymbolTableEntry* SymbolTable::lookup(const std::string& name) {
         if (parent == nullptr) return nullptr;
         return parent->lookup(name);
     }
-    // Otherwise return the entry
+    // Otherwise, return the entry
     return &symbols.at(name);
 }
 
@@ -23,7 +23,7 @@ void SymbolTable::update(const std::string& name, SymbolState newState) {
         if (parent == nullptr) throw std::runtime_error("Updating a non-existent symbol: " + name);
         parent->update(name, newState);
     }
-    // Otherwise update the entry
+    // Otherwise, update the entry
     symbols.at(name).updateState(newState);
 }
 
@@ -33,7 +33,7 @@ void SymbolTable::update(const std::string& name, SymbolType newType) {
         if (parent == nullptr) throw std::runtime_error("Updating a non-existent symbol: " + name);
         parent->update(name, newType);
     }
-    // Otherwise update the entry
+    // Otherwise, update the entry
     symbols.at(name).updateType(newType);
 }
 

--- a/compiler/src/analyzer/SymbolTableEntry.cpp
+++ b/compiler/src/analyzer/SymbolTableEntry.cpp
@@ -20,7 +20,7 @@ void SymbolTableEntry::updateState(SymbolState newState) {
 }
 
 void SymbolTableEntry::updateType(SymbolType newType) {
-    if (type != TYPE_DYN) throw std::runtime_error("Compiler error: Cannot change type of non-dyn");
+    if (type != TYPE_DYN) throw std::runtime_error("Internal compiler error: Cannot change type of non-dyn");
     type = newType;
 }
 

--- a/compiler/src/exception/SemanticError.h
+++ b/compiler/src/exception/SemanticError.h
@@ -16,7 +16,8 @@ enum SemanticErrorType {
     REASSIGN_CONST_VARIABLE,
     CONDITION_MUST_BE_BOOL,
     PARAMETER_TYPES_DO_NOT_MATCH,
-    MISSING_MAIN_FUNCTION
+    MISSING_MAIN_FUNCTION,
+    FCT_PARAM_IS_TYPE_DYN,
 };
 
 class SemanticError : public std::exception {
@@ -57,6 +58,9 @@ public:
                 break;
             case MISSING_MAIN_FUNCTION:
                 messagePrefix = "Spice programs must contain a main function";
+                break;
+            case FCT_PARAM_IS_TYPE_DYN:
+                messagePrefix = "Parameter type dyn not valid in function/procedure definition without default value";
                 break;
         }
         errorMessage = messagePrefix + ": " + message;

--- a/compiler/src/generator/GeneratorVisitor.cpp
+++ b/compiler/src/generator/GeneratorVisitor.cpp
@@ -119,8 +119,11 @@ antlrcpp::Any GeneratorVisitor::visitFunctionDef(SpiceParser::FunctionDefContext
     std::string scopeId = ScopeIdUtil::getScopeId(ctx);
     currentScope = currentScope->getChild(scopeId);
 
-    // Create function itself
+    // Get return type
+    currentVar = RETURN_VARIABLE_NAME;
     auto returnType = visit(ctx->dataType()).as<llvm::Type*>();
+
+    // Create function itself
     std::vector<std::string> paramNames;
     std::vector<llvm::Type*> paramTypes;
     for (auto& param : ctx->paramLstDef()->declStmt()) { // Parameters without default value
@@ -704,8 +707,6 @@ antlrcpp::Any GeneratorVisitor::visitDataType(SpiceParser::DataTypeContext* ctx)
 
     // Data type is dyn
     if (ctx->TYPE_DYN()) {
-        std::cout << currentScope->toString() << std::endl;
-        std::cout << currentVar << std::endl;
         auto symbolTableEntry = currentScope->lookup(currentVar);
         switch (symbolTableEntry->getType()) {
             case TYPE_DOUBLE: return (llvm::Type*) llvm::Type::getDoubleTy(*context);

--- a/compiler/src/generator/GeneratorVisitor.h
+++ b/compiler/src/generator/GeneratorVisitor.h
@@ -6,6 +6,7 @@
 #include <exception/IRError.h>
 #include <analyzer/SymbolTable.h>
 #include <util/ScopeIdUtil.h>
+#include <analyzer/AnalyzerVisitor.h>
 
 #include <llvm/ADT/APFloat.h>
 #include <llvm/ADT/Optional.h>

--- a/compiler/test/AnalyzerTest.cpp
+++ b/compiler/test/AnalyzerTest.cpp
@@ -111,6 +111,14 @@ const AnalyzerParams ANALYZER_TEST_PARAMETERS[] = {
             "error-must-contain-main-function",
             "Spice programs must contain a main function: No main function found."
         },
+        {
+            "error-function-arg-decl-type-dyn",
+            "Parameter type dyn not valid in function/procedure definition without default value: Type of parameter 'arg2' is invalid"
+        },
+        {
+            "error-dyn-return-types-not-matching",
+            "Wrong data type for operator: Passed wrong data type to return statement"
+        },
         // Successful tests
         {
             "success-fibonacci",

--- a/compiler/test/test-files/error-dyn-return-types-not-matching/source.spice
+++ b/compiler/test/test-files/error-dyn-return-types-not-matching/source.spice
@@ -1,0 +1,10 @@
+f<dyn> testFunction() {
+    if true { return "test"; }
+    return 0.2;
+}
+
+f<int> main() {
+    dyn ret = testFunction();
+    printf("Result: ", ret);
+    return 0;
+}

--- a/compiler/test/test-files/error-function-arg-decl-type-dyn/source.spice
+++ b/compiler/test/test-files/error-function-arg-decl-type-dyn/source.spice
@@ -1,0 +1,8 @@
+f<int> testFunction(int arg0, dyn arg1 = "value", dyn arg2) {
+    return 1;
+}
+
+f<int> main() {
+    testFunction();
+    return 0;
+}

--- a/media/functions.spice
+++ b/media/functions.spice
@@ -1,10 +1,11 @@
-f<double> calledFunction(int mandatoryParam, dyn optionalParam = true) {
+f<dyn> calledFunction(int mandatoryParam, dyn optionalParam = true) {
     printf("Mandatory: %d", mandatoryParam);
     printf("Optional: %d", optionalParam);
-    return 0.0;
+    return 0.1;
 }
 
 f<int> main() {
-    calledFunction(1, false);
+    dyn res = calledFunction(1, false);
+    printf("Result: %d", res);
     return 0;
 }

--- a/media/functions.spice
+++ b/media/functions.spice
@@ -1,4 +1,4 @@
-f<double> calledFunction(int mandatoryParam, bool optionalParam = true) {
+f<double> calledFunction(int mandatoryParam, dyn optionalParam = true) {
     printf("Mandatory: %d", mandatoryParam);
     printf("Optional: %d", optionalParam);
     return 0.0;


### PR DESCRIPTION
- Allow dyn as function/procedure argument type, but only if the argument has a default value
  - [x] Add tests
- Allow dyn as return type for functions
  - [x] Add tests